### PR TITLE
Update igraph installation steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This is used to build depedency graphs.
 If you want to compile it from source, make sure GraphML is enabled (see http://igraph.org/c/ for details)
 
     cd igraph
+    bootstrap.sh
     ./configure
     make
     make check


### PR DESCRIPTION
I couldn't install igraph without first running the `bootstrap.sh` script.

Because igraph's travis configuration also performs this step in its installation script, I assume this patch is good to go (see: https://github.com/igraph/igraph/blob/master/.travis.yml).